### PR TITLE
Simple capture

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    backspin (0.5.0)
+    backspin (0.6.0)
       ostruct
       rspec-mocks (~> 3)
 

--- a/lib/backspin/command.rb
+++ b/lib/backspin/command.rb
@@ -52,6 +52,8 @@ module Backspin
         Open3::Capture3
       when "Kernel::System"
         ::Kernel::System
+      when "Backspin::Capturer"
+        Backspin::Capturer
       else
         # Default to capture3 for backwards compatibility
         Open3::Capture3
@@ -96,4 +98,9 @@ end
 # Define the Kernel::System class for identification
 module ::Kernel
   class System; end
+end
+
+# Define the Backspin::Capturer class for identification
+module Backspin
+  class Capturer; end
 end

--- a/lib/backspin/version.rb
+++ b/lib/backspin/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Backspin
-  VERSION = "0.5.0"
+  VERSION = "0.6.0"
 end

--- a/release.rake
+++ b/release.rake
@@ -4,7 +4,7 @@ require "bundler/gem_tasks"
 
 # Simplified release tasks using gem-release
 # Install with: gem install gem-release
-
+# https://github.com/svenfuchs/gem-release
 namespace :release do
   desc "Release a new version (bump, tag, release)"
   task :version, [:level] do |t, args|

--- a/spec/backspin_capture_spec.rb
+++ b/spec/backspin_capture_spec.rb
@@ -1,13 +1,207 @@
+require "spec_helper"
+
 RSpec.describe "Backspin.capture" do
+  around do |example|
+    with_tmp_dir_for_backspin(&example)
+  end
+
   context "capture" do
-    it "captures stdout and stderr from anything in the block (regardless of how called)"
+    it "captures stdout and stderr from anything in the block (regardless of how called)" do
+      record_name = "capture_all_output"
 
-    it "records to a record file with stdout and stderr, command_type: 'backspin-capturer'"
+      result = Backspin.capture(record_name) do
+        puts "Hello from puts"
+        $stdout.print "Direct stdout write\n"
+        warn "Error message"
 
-    it "acts the same as run: record when called with no matching record file"
+        system("echo 'From system command'")
+        puts `echo 'From backticks'`
 
-    it "acts the same as run: verify when called with a matching record file"
+        stdout, _, _ = Open3.capture3("echo", "From Open3")
+        puts stdout
 
-    it "uses the same recorder and record interface as Backspin.run"
+        "block return value"
+      end
+
+      expect(result.output).to eq("block return value")
+      expect(result.mode).to eq(:record)
+
+      record_path = Backspin.configuration.backspin_dir.join("capture_all_output.yml")
+      expect(record_path).to exist
+
+      yaml_content = YAML.load_file(record_path)
+      expect(yaml_content).to be_a(Hash)
+      expect(yaml_content["commands"]).to be_an(Array)
+      expect(yaml_content["commands"].size).to eq(1)
+
+      command = yaml_content["commands"].first
+      expect(command["stdout"]).to include("Hello from puts")
+      expect(command["stdout"]).to include("Direct stdout write")
+      expect(command["stdout"]).to include("From system command")
+      expect(command["stdout"]).to include("From backticks")
+      expect(command["stdout"]).to include("From Open3")
+      expect(command["stderr"]).to include("Error message")
+    end
+
+    it "records to a record file with stdout and stderr, command_type: 'Backspin::Capturer'" do
+      record_name = "capture_command_type"
+
+      Backspin.capture(record_name) do
+        puts "Test output"
+        warn "Test error"
+      end
+
+      yaml_content = YAML.load_file(Backspin.configuration.backspin_dir.join("capture_command_type.yml"))
+      command = yaml_content["commands"].first
+
+      expect(command["command_type"]).to eq("Backspin::Capturer")
+      expect(command["args"]).to eq(["<captured block>"])
+      expect(command["stdout"]).to eq("Test output\n")
+      expect(command["stderr"]).to eq("Test error\n")
+      expect(command["status"]).to eq(0)
+      expect(command["recorded_at"]).to be_a(String)
+    end
+
+    it "acts the same as run: record when called with no matching record file" do
+      record_name = "capture_record_mode"
+
+      result = Backspin.capture(record_name) do
+        puts "Recording this output"
+        42
+      end
+
+      expect(result.mode).to eq(:record)
+      expect(result.output).to eq(42)
+      expect(Backspin.configuration.backspin_dir.join("capture_record_mode.yml")).to exist
+    end
+
+    it "acts the same as run: verify when called with a matching record file" do
+      record_name = "capture_verify_mode"
+
+      Backspin.capture(record_name) do
+        puts "Expected output"
+      end
+
+      result = Backspin.capture(record_name) do
+        puts "Expected output"
+      end
+
+      expect(result.mode).to eq(:verify)
+      expect(result.verified?).to be true
+
+      result = Backspin.capture(record_name) do
+        puts "Different output"
+      end
+
+      expect(result.mode).to eq(:verify)
+      expect(result.verified?).to be false
+    end
+
+    it "uses the same recorder and record interface as Backspin.run" do
+      record_name = "capture_uses_same_interface"
+
+      result = Backspin.capture(record_name, mode: :record) do
+        puts "Test"
+      end
+
+      expect(result).to be_a(Backspin::RecordResult)
+      expect(result.record).to be_a(Backspin::Record)
+
+      custom_matcher = ->(recorded, actual) { recorded["stdout"] == actual["stdout"] }
+
+      result = Backspin.capture(record_name, mode: :verify, matcher: custom_matcher) do
+        puts "Test"
+      end
+
+      expect(result.verified?).to be true
+
+      Backspin.capture("capture_with_timestamp", mode: :record) do
+        puts "The time is: 2024-01-01 10:00:00"
+        puts "Static content"
+      end
+
+      timestamp_normalizer = ->(recorded, actual) {
+        recorded_normalized = recorded["stdout"].gsub(/\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}/, "[TIMESTAMP]")
+        actual_normalized = actual["stdout"].gsub(/\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}/, "[TIMESTAMP]")
+
+        recorded_normalized == actual_normalized &&
+          recorded["stderr"] == actual["stderr"] &&
+          recorded["status"] == actual["status"]
+      }
+
+      result = Backspin.capture("capture_with_timestamp", mode: :verify, matcher: timestamp_normalizer) do
+        puts "The time is: 2024-12-25 15:30:45"
+        puts "Static content"
+      end
+
+      expect(result.verified?).to be true
+
+      result_without_matcher = Backspin.capture("capture_with_timestamp", mode: :verify) do
+        puts "The time is: 2024-12-25 15:30:45"
+        puts "Static content"
+      end
+
+      expect(result_without_matcher.verified?).to be false
+
+      filter = ->(data) { data.merge("filtered" => true) }
+
+      Backspin.capture("capture_with_filter", mode: :record, filter: filter) do
+        puts "Test"
+      end
+
+      yaml_content = YAML.load_file(Backspin.configuration.backspin_dir.join("capture_with_filter.yml"))
+      expect(yaml_content["commands"].first["filtered"]).to be true
+    end
+
+    it "supports matchers that can transform both recorded and actual content" do
+      Backspin.capture("capture_dynamic_content", mode: :record) do
+        puts "Process ID: #{Process.pid}"
+        puts "Ruby version: #{RUBY_VERSION}"
+        warn "Warning with PID: #{Process.pid}"
+      end
+
+      content_normalizer = ->(recorded, actual) {
+        recorded_stdout = recorded["stdout"]
+          .gsub(/Process ID: \d+/, "Process ID: [PID]")
+          .gsub(/Ruby version: \d+\.\d+\.\d+/, "Ruby version: [VERSION]")
+
+        actual_stdout = actual["stdout"]
+          .gsub(/Process ID: \d+/, "Process ID: [PID]")
+          .gsub(/Ruby version: \d+\.\d+\.\d+/, "Ruby version: [VERSION]")
+
+        recorded_stderr = recorded["stderr"]
+          .gsub(/PID: \d+/, "PID: [PID]")
+
+        actual_stderr = actual["stderr"]
+          .gsub(/PID: \d+/, "PID: [PID]")
+
+        recorded_stdout == actual_stdout && recorded_stderr == actual_stderr
+      }
+
+      result = Backspin.capture("capture_dynamic_content", mode: :verify, matcher: content_normalizer) do
+        puts "Process ID: #{Process.pid}"
+        puts "Ruby version: #{RUBY_VERSION}"
+        warn "Warning with PID: #{Process.pid}"
+      end
+
+      expect(result.verified?).to be true
+
+      field_matchers = {
+        stdout: ->(recorded, actual) {
+          recorded.gsub(/\d+/, "[NUM]") == actual.gsub(/\d+/, "[NUM]")
+        },
+        stderr: ->(recorded, actual) {
+          recorded.gsub(/\d+/, "[NUM]") == actual.gsub(/\d+/, "[NUM]")
+        }
+      }
+
+      result = Backspin.capture("capture_dynamic_content", mode: :verify, matcher: field_matchers) do
+        puts "Process ID: #{Process.pid}"
+        puts "Ruby version: #{RUBY_VERSION}"
+        warn "Warning with PID: #{Process.pid}"
+      end
+
+      expect(result.verified?).to be true
+    end
   end
 end

--- a/spec/backspin_capture_spec.rb
+++ b/spec/backspin_capture_spec.rb
@@ -1,0 +1,13 @@
+RSpec.describe "Backspin.capture" do
+  context "capture" do
+    it "captures stdout and stderr from anything in the block (regardless of how called)"
+
+    it "records to a record file with stdout and stderr, command_type: 'backspin-capturer'"
+
+    it "acts the same as run: record when called with no matching record file"
+
+    it "acts the same as run: verify when called with a matching record file"
+
+    it "uses the same recorder and record interface as Backspin.run"
+  end
+end

--- a/spec/backspin_spec.rb
+++ b/spec/backspin_spec.rb
@@ -90,39 +90,29 @@ RSpec.describe Backspin do
     end
   end
 
-  context "capture" do
-    it "captures stdout and stderr from anything in the block (regardless of how called)"
+  context "run with invalid args" do
+    it "raises ArgumentError when no record name is provided" do
+      expect do
+        Backspin.run do
+          Open3.capture3("echo hello")
+        end
+      end.to raise_error(ArgumentError, /wrong number of arguments/)
+    end
 
-    it "records to a record file with stdout and stderr, command_type: 'backspin-capturer'"
+    it "raises ArgumentError when record name is nil" do
+      expect do
+        Backspin.run(nil, mode: :record) do
+          Open3.capture3("echo hello")
+        end
+      end.to raise_error(ArgumentError, "record_name is required")
+    end
 
-    it "acts the same as run: record when called with no matching record file"
-    it "acts the same as run: verify when called with a matching record file"
-
-    it "uses the same recorder and record interface as Backspin.run"
-  end
-
-  context "run with invalid args"
-  it "raises ArgumentError when no record name is provided" do
-    expect do
-      Backspin.run do
-        Open3.capture3("echo hello")
-      end
-    end.to raise_error(ArgumentError, /wrong number of arguments/)
-  end
-
-  it "raises ArgumentError when record name is nil" do
-    expect do
-      Backspin.run(nil, mode: :record) do
-        Open3.capture3("echo hello")
-      end
-    end.to raise_error(ArgumentError, "record_name is required")
-  end
-
-  it "raises ArgumentError when record name is empty" do
-    expect do
-      Backspin.run("", mode: :record) do
-        Open3.capture3("echo hello")
-      end
-    end.to raise_error(ArgumentError, "record_name is required")
+    it "raises ArgumentError when record name is empty" do
+      expect do
+        Backspin.run("", mode: :record) do
+          Open3.capture3("echo hello")
+        end
+      end.to raise_error(ArgumentError, "record_name is required")
+    end
   end
 end

--- a/spec/backspin_spec.rb
+++ b/spec/backspin_spec.rb
@@ -90,6 +90,17 @@ RSpec.describe Backspin do
     end
   end
 
+  context "capture" do
+    it "captures stdout and stderr from anything in the block (regardless of how called)"
+
+    it "records to a record file with stdout and stderr, command_type: 'backspin-capturer'"
+
+    it "acts the same as run: record when called with no matching record file"
+    it "acts the same as run: verify when called with a matching record file"
+
+    it "uses the same recorder and record interface as Backspin.run"
+  end
+
   context "run with invalid args"
   it "raises ArgumentError when no record name is provided" do
     expect do


### PR DESCRIPTION
Add `Backspin.capture` API for a simpler approach: recording all stdout/stderr output

## Summary
* Adds new `Backspin.capture` API that records all stdout/stderr output from a block
* Captures output from any source: `puts`, `system`, backticks, `Open3`, direct `$stdout` writes
* bump to 0.6.0 for this new feature

## Implementation Details
The capture API intercepts all output at the file descriptor level by temporarily redirecting `$stdout` and `$stderr` to temp files. This allows it to capture output from any command or method call within the block, not just `Open3.capture3` calls.

### New public API:
```ruby
result = Backspin.capture("record_name") do
  # Any code that produces stdout/stderr
end
```

- Supports all recording modes: `:auto`, `:record`, `:verify`, `:playback`
- Records output under `Backspin::Capturer` command type
- Returns the block's return value while recording all output
- Works with any output method (puts, system, backticks, Open3, etc.)