### PR TITLE
Raise by default on verification failure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,9 +41,10 @@ bin/rake standard                # Alternative: Run via Rake task
 ### Core Components
 
 **Backspin Module** (`lib/backspin.rb`)
-- Main API: `call`, `verify`, `verify!`, `use_record`
+- Main API: `run`, `run!` (both raise on verification failure by default)
+- Legacy API: `call`, `verify`, `verify!`, `use_record`
 - Credential scrubbing logic
-- Configuration management
+- Configuration management (including `raise_on_verification_failure` which defaults to `true`)
 
 **Command Class** (`lib/backspin.rb`)
 - Represents a single CLI execution

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,9 +42,10 @@ bin/rake standard                # Alternative: Run via Rake task
 
 **Backspin Module** (`lib/backspin.rb`)
 - Main API: `run`, `run!` (both raise on verification failure by default)
+- Capture API: `capture` (raises `VerificationError` on verification failure by default)
 - Legacy API: `call`, `verify`, `verify!`, `use_record`
 - Credential scrubbing logic
-- Configuration management (including `raise_on_verification_failure` which defaults to `true`)
+- Configuration management (including `raise_on_verification_failure` which defaults to `true` and affects both `run` and `capture`)
 
 **Command Class** (`lib/backspin.rb`)
 - Represents a single CLI execution

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ And then run `bundle install`.
 
 ### Quick Start
 
-The simplest way to use Backspin is with the `run` method, which automatically records on the first execution and verifies on subsequent runs:
+The simplest way to use Backspin is with the `run` method, which automatically records on the first execution and verifies on subsequent runs.
 
 ```ruby
 require "backspin"
@@ -214,11 +214,18 @@ You can configure Backspin's behavior globally:
 
 ```ruby
 Backspin.configure do |config|
+  # Both run and capture methods will raise on verification failure by default
   config.raise_on_verification_failure = false # default is true
   config.backspin_dir = "spec/fixtures/cli_records" # default is "fixtures/backspin"
   config.scrub_credentials = false # default is true
 end
 ```
+
+The `raise_on_verification_failure` setting affects both `Backspin.run` and `Backspin.capture`:
+- When `true` (default): Both methods raise exceptions on verification failure
+  - `run` raises `RSpec::Expectations::ExpectationNotMetError`
+  - `capture` raises `Backspin::VerificationError` (framework-agnostic)
+- When `false`: Both methods return a result with `verified?` set to false
 
 If you need to disable the raising behavior for a specific test, you can temporarily configure it:
 

--- a/README.md
+++ b/README.md
@@ -43,17 +43,19 @@ result = Backspin.run("my_command") do
   Open3.capture3("echo hello world")
 end
 
-# Subsequent runs: verifies the output matches
-result = Backspin.run("my_command") do
-  Open3.capture3("echo hello world")
+# Subsequent runs: verifies the output matches and raises on mismatch
+Backspin.run("my_command") do
+  Open3.capture3("echo hello world")  # Passes - output matches
 end
 
-# Use run! to automatically fail tests on mismatch
-Backspin.run!("my_command") do
-  Open3.capture3("echo hello mars")
+# This will raise an error automatically
+Backspin.run("my_command") do
+  Open3.capture3("echo hello mars")  
 end
-# Raises an error because stdout will not match the recorded output
+# Raises RSpec::Expectations::ExpectationNotMetError because output doesn't match
 ```
+
+By default, `Backspin.run` will raise an exception when verification fails, making your tests fail automatically. This is the recommended approach for most scenarios.
 
 ### Recording Modes
 
@@ -83,17 +85,24 @@ result = Backspin.run("slow_command", mode: :playback) do
 end
 ```
 
-### Using run! for automatic test failures
+### The run! method
 
-The `run!` method works exactly like `run` but automatically fails the test if verification fails:
+**NOTE:** This method is deprecated and will be removed soon.
+
+The `run!` method is maintained for backwards compatibility and works identically to `run`. Since `run` now raises on verification failure by default, both methods behave the same way:
 
 ```ruby
-# Automatically fail the test if output doesn't match
+# Both of these are equivalent and will raise on verification failure
+Backspin.run("echo_test") do
+  Open3.capture3("echo hello")
+end
+
 Backspin.run!("echo_test") do
   Open3.capture3("echo hello")
 end
-# Raises an error with detailed diff if verification fails from recorded data in "echo_test.yml"
 ```
+
+For new code, we recommend using `run` as it's the primary API method.
 
 ### Custom matchers
 
@@ -198,6 +207,35 @@ result.commands[3].stderr  # curl errors if any
 ```
 
 When verifying multiple commands, Backspin ensures all commands match in the exact order they were recorded. If any command differs, you'll get a detailed error showing which commands failed.
+
+### Configuration
+
+You can configure Backspin's behavior globally:
+
+```ruby
+Backspin.configure do |config|
+  config.raise_on_verification_failure = false # default is true
+  config.backspin_dir = "spec/fixtures/cli_records" # default is "fixtures/backspin"
+  config.scrub_credentials = false # default is true
+end
+```
+
+If you need to disable the raising behavior for a specific test, you can temporarily configure it:
+
+```ruby
+# Temporarily disable raising for this block
+Backspin.configure do |config|
+  config.raise_on_verification_failure = false
+end
+
+result = Backspin.run("my_test") do
+  Open3.capture3("echo different")
+end
+# result.verified? will be false but won't raise
+
+# Reset configuration
+Backspin.reset_configuration!
+```
 
 ### Credential Scrubbing
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Backspin 
+# Backspin
 
 [![Ruby](https://img.shields.io/badge/ruby-%23CC342D.svg?style=flat&logo=ruby&logoColor=white)](https://www.ruby-lang.org/)
 [![Gem Version](https://img.shields.io/gem/v/backspin)](https://rubygems.org/gems/backspin)

--- a/fixtures/backspin/all_for_logging.yml
+++ b/fixtures/backspin/all_for_logging.yml
@@ -4,8 +4,9 @@ format_version: '2.0'
 commands:
 - command_type: Open3::Capture3
   args:
-  - date
-  stdout: 'Wed Jun 11 02:48:13 CDT 2025
+  - echo
+  - 'test output with : colons'
+  stdout: 'test output with : colons
 
     '
   stderr: ''

--- a/fixtures/backspin/strict_test.yml
+++ b/fixtures/backspin/strict_test.yml
@@ -5,9 +5,8 @@ commands:
 - command_type: Open3::Capture3
   args:
   - echo
-  - "'hello"
-  - world'
-  stdout: 'HELLO WORLD
+  - exact output
+  stdout: 'exact output
 
     '
   stderr: ''

--- a/fixtures/backspin/version_test.yml
+++ b/fixtures/backspin/version_test.yml
@@ -4,9 +4,9 @@ format_version: '2.0'
 commands:
 - command_type: Open3::Capture3
   args:
-  - ruby
-  - "--version"
-  stdout: 'ruby 3.4.4 (2025-05-14 revision a38531fd3f) +PRISM [arm64-darwin24]
+  - echo
+  - ruby version 3.4.5
+  stdout: 'ruby version 3.4.5
 
     '
   stderr: ''

--- a/lib/backspin.rb
+++ b/lib/backspin.rb
@@ -79,7 +79,7 @@ module Backspin
       recorder = Recorder.new(record: record, mode: mode, matcher: matcher, filter: filter)
 
       # Execute the appropriate mode
-      case mode
+      result = case mode
       when :record
         recorder.setup_recording_stubs(:capture3, :system)
         recorder.perform_recording(&block)
@@ -90,6 +90,17 @@ module Backspin
       else
         raise ArgumentError, "Unknown mode: #{mode}"
       end
+
+      # Check if we should raise on verification failure
+      if configuration.raise_on_verification_failure && result.verified? == false
+        error_message = "Backspin verification failed!\n"
+        error_message += "Record: #{result.record.path}\n"
+        error_message += "\n#{result.error_message}" if result.error_message
+
+        raise RSpec::Expectations::ExpectationNotMetError, error_message
+      end
+
+      result
     end
 
     # Strict version of run that raises on verification failure

--- a/lib/backspin/configuration.rb
+++ b/lib/backspin/configuration.rb
@@ -8,11 +8,14 @@ module Backspin
     attr_accessor :scrub_credentials
     # The directory where backspin will store its files - defaults to fixtures/backspin
     attr_accessor :backspin_dir
+    # Whether to raise an exception when verification fails in `run` method - defaults to true
+    attr_accessor :raise_on_verification_failure
     # Regex patterns to scrub from saved output
     attr_reader :credential_patterns
 
     def initialize
       @scrub_credentials = true
+      @raise_on_verification_failure = true
       @credential_patterns = default_credential_patterns
       @backspin_dir = Pathname(Dir.pwd).join("fixtures", "backspin")
     end

--- a/script/lint
+++ b/script/lint
@@ -1,6 +1,22 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Run Standard Ruby linter
-echo "Running Standard Ruby linter..."
-bundle exec standardrb "$@"
+FIX_OPT="--no-fix"
+while [[ $# -gt 0 ]]; do
+  case $1 in
+      -f|--fix)
+          FIX_OPT="--fix"
+          shift
+          ;;
+      --fix-unsafely)
+          FIX_OPT="--fix-unsafely"
+          shift
+          ;;
+      *)
+          echo "Error: Unknown option: $1"
+          exit 1
+          ;;
+  esac
+done
+
+bundle exec standardrb "$@" $FIX_OPT

--- a/script/run_affected_tests
+++ b/script/run_affected_tests
@@ -1,0 +1,179 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "json"
+require "pathname"
+require "open3"
+
+class AffectedTestRunner
+  EXIT_SUCCESS = 0
+  EXIT_FAILURE = 2
+
+  def initialize
+    @project_dir = ENV["CLAUDE_PROJECT_DIR"]
+    validate_environment!
+  end
+
+  def run
+    input_data = parse_input
+    file_path = extract_file_path(input_data)
+
+    return EXIT_SUCCESS unless ruby_file?(file_path)
+
+    validated_path = validate_and_normalize_path(file_path)
+    return EXIT_SUCCESS unless validated_path
+
+    test_file = determine_test_file(validated_path)
+    return EXIT_SUCCESS unless test_file
+
+    run_tests(test_file)
+  rescue => e
+    abort_to_claude("Unexpected error: #{e.message}")
+  end
+
+  private
+
+  def validate_environment!
+    unless @project_dir
+      abort_to_claude("CLAUDE_PROJECT_DIR environment variable not set")
+    end
+
+    unless Dir.exist?(@project_dir)
+      abort_to_claude("CLAUDE_PROJECT_DIR does not exist: #{@project_dir}")
+    end
+
+    @project_path = Pathname.new(@project_dir).realpath
+  rescue => e
+    abort_to_claude("Invalid CLAUDE_PROJECT_DIR: #{e.message}")
+  end
+
+  def parse_input
+    input = $stdin.read
+    JSON.parse(input)
+  rescue JSON::ParserError => e
+    abort_to_claude("Invalid JSON input: #{e.message}")
+  end
+
+  def extract_file_path(data)
+    file_path = data.dig("tool_input", "file_path")
+
+    unless file_path && !file_path.empty?
+      abort_to_claude("No file_path provided in input")
+    end
+
+    file_path
+  end
+
+  def ruby_file?(file_path)
+    file_path.end_with?(".rb")
+  end
+
+  def validate_and_normalize_path(file_path)
+    # Expand the path to get absolute path
+    expanded_path = File.expand_path(file_path, @project_dir)
+    normalized_path = Pathname.new(expanded_path).cleanpath
+
+    # Check if the path is within the project directory
+    unless normalized_path.to_s.start_with?(@project_path.to_s)
+      log_info("File path outside project directory: #{file_path}")
+      return nil
+    end
+
+    # Convert back to relative path from project root for consistency
+    normalized_path.relative_path_from(@project_path).to_s
+  rescue => e
+    log_info("Invalid file path: #{file_path} - #{e.message}")
+    nil
+  end
+
+  def determine_test_file(file_path)
+    log_info("Determining tests for: #{file_path}")
+
+    if spec_file?(file_path)
+      # If a spec file was modified, run just that spec
+      test_file = file_path
+      log_info("Running single spec: #{test_file}")
+    elsif lib_file?(file_path)
+      # If a lib file was modified, try to find corresponding spec
+      test_file = lib_to_spec_path(file_path)
+
+      if File.exist?(File.join(@project_dir, test_file))
+        log_info("Running corresponding spec: #{test_file}")
+      else
+        # No corresponding spec found, run all tests
+        log_info("No corresponding spec found, running all tests")
+        test_file = "spec"
+      end
+    else
+      # For other Ruby files, run all tests
+      log_info("Running all tests")
+      test_file = "spec"
+    end
+
+    # Validate test file/directory exists
+    full_test_path = File.join(@project_dir, test_file)
+    unless File.exist?(full_test_path)
+      abort_to_claude("Test file/directory does not exist: #{test_file}")
+    end
+
+    test_file
+  end
+
+  def spec_file?(file_path)
+    file_path.match?(%r{^.*spec/.*_spec\.rb$})
+  end
+
+  def lib_file?(file_path)
+    file_path.match?(%r{^.*lib/.*})
+  end
+
+  def lib_to_spec_path(lib_path)
+    # Convert lib/backspin/foo.rb to spec/backspin/foo_spec.rb
+    lib_path.sub(%r{^(.*/)?lib/}, '\1spec/')
+      .sub(/\.rb$/, "_spec.rb")
+  end
+
+  def run_tests(test_file)
+    rspec_path = File.join(@project_dir, "bin", "rspec")
+
+    unless File.executable?(rspec_path)
+      abort_to_claude("rspec binary not found or not executable: #{rspec_path}")
+    end
+
+    log_info("Running: bin/rspec #{test_file}")
+
+    # Change to project directory for command execution
+    Dir.chdir(@project_dir) do
+      stdout, stderr, status = Open3.capture3("bin/rspec", test_file)
+
+      # Output both stdout and stderr
+      $stdout.print stdout
+      $stderr.print stderr
+
+      if status.success?
+        log_info("✅ Tests passed")
+        EXIT_SUCCESS
+      else
+        warn("❌ Tests failed - fix before continuing")
+        EXIT_FAILURE
+      end
+    end
+  rescue => e
+    abort_to_claude("Failed to run tests: #{e.message}")
+  end
+
+  def log_info(message)
+    warn(message)
+  end
+
+  def abort_to_claude(message)
+    warn("❌ ERROR: #{message}")
+    exit EXIT_FAILURE
+  end
+end
+
+# Run the script
+if __FILE__ == $0
+  runner = AffectedTestRunner.new
+  exit runner.run
+end

--- a/spec/backspin/filter_spec.rb
+++ b/spec/backspin/filter_spec.rb
@@ -87,6 +87,12 @@ RSpec.describe "Backspin filtering support" do
   end
 
   describe "Backspin.run with filter and different modes" do
+    before do
+      # Ensure record doesn't exist from previous runs
+      record_path = Backspin.configuration.backspin_dir.join("use_record_filter.yml")
+      FileUtils.rm_f(record_path)
+    end
+
     it "applies filter when recording (auto mode)" do
       filter = lambda { |data|
         data["stdout"] = data["stdout"].upcase

--- a/spec/backspin/system_support_spec.rb
+++ b/spec/backspin/system_support_spec.rb
@@ -71,12 +71,14 @@ RSpec.describe "Backspin system() support" do
         system("true") # exit status 0
       end
 
-      # Verify with a failing command - should fail
-      result = Backspin.run("verify_system_diff") do
-        system("false") # exit status 1
+      # Verify with a failing command - should raise
+      expect do
+        Backspin.run("verify_system_diff") do
+          system("false") # exit status 1
+        end
+      end.to raise_error(RSpec::Expectations::ExpectationNotMetError) do |error|
+        expect(error.message).to include("Backspin verification failed!")
       end
-
-      expect(result.verified?).to be false
     end
   end
 

--- a/spec/backspin/unified_api_spec.rb
+++ b/spec/backspin/unified_api_spec.rb
@@ -46,21 +46,23 @@ RSpec.describe "Backspin.run unified API" do
         expect(result.all_stdout).to eq(["first run\n"])
       end
 
-      it "returns false for verified? when output doesn't match" do
+      it "raises when verification fails due to output mismatch" do
         # Record
         Backspin.run("unified_mismatch") do
           Open3.capture3("echo original")
         end
 
         # Verify with different output
-        result = Backspin.run("unified_mismatch") do
-          Open3.capture3("echo different")
+        expect do
+          Backspin.run("unified_mismatch") do
+            Open3.capture3("echo different")
+          end
+        end.to raise_error(RSpec::Expectations::ExpectationNotMetError) do |error|
+          expect(error.message).to include("Backspin verification failed!")
+          expect(error.message).to include("Command 1:")
+          expect(error.message).to include("-original")
+          expect(error.message).to include("+different")
         end
-
-        expect(result).not_to be_verified
-        expect(result.diff).to include("Command 1:")
-        expect(result.diff).to include("-original")
-        expect(result.diff).to include("+different")
       end
     end
 

--- a/spec/backspin/unified_api_spec.rb
+++ b/spec/backspin/unified_api_spec.rb
@@ -26,17 +26,14 @@ RSpec.describe "Backspin.run unified API" do
         expect(result.all_status).to eq([0])
         expect(result).to be_success
 
-        # Verify file was created
         expect(Backspin.configuration.backspin_dir.join("unified_basic.yml")).to exist
       end
 
       it "verifies on subsequent runs when record exists" do
-        # First run - record
         Backspin.run("unified_verify") do
           Open3.capture3("echo first run")
         end
 
-        # Second run - verify
         result = Backspin.run("unified_verify") do
           Open3.capture3("echo first run")
         end
@@ -47,12 +44,10 @@ RSpec.describe "Backspin.run unified API" do
       end
 
       it "raises when verification fails due to output mismatch" do
-        # Record
         Backspin.run("unified_mismatch") do
           Open3.capture3("echo original")
         end
 
-        # Verify with different output
         expect do
           Backspin.run("unified_mismatch") do
             Open3.capture3("echo different")
@@ -68,12 +63,10 @@ RSpec.describe "Backspin.run unified API" do
 
     context "with explicit mode option" do
       it "always records with mode: :record" do
-        # First run
         Backspin.run("mode_record", mode: :record) do
           Open3.capture3("echo first")
         end
 
-        # Second run with mode: :record should overwrite
         result = Backspin.run("mode_record", mode: :record) do
           Open3.capture3("echo second")
         end
@@ -81,7 +74,6 @@ RSpec.describe "Backspin.run unified API" do
         expect(result).to be_recorded
         expect(result.stdout).to eq("second\n")
 
-        # Verify it was overwritten
         result = Backspin.run("mode_record", mode: :verify) do
           Open3.capture3("echo second")
         end
@@ -89,12 +81,10 @@ RSpec.describe "Backspin.run unified API" do
       end
 
       it "always verifies with mode: :verify" do
-        # Create record first
         Backspin.run("mode_verify", mode: :record) do
           Open3.capture3("echo test")
         end
 
-        # Verify mode
         result = Backspin.run("mode_verify", mode: :verify) do
           Open3.capture3("echo test")
         end
@@ -112,30 +102,26 @@ RSpec.describe "Backspin.run unified API" do
       end
 
       it "returns recorded output with mode: :playback" do
-        # Create record
         Backspin.run("playback_test", mode: :record) do
           Open3.capture3("echo playback")
         end
 
-        # Playback mode
         result = Backspin.run("playback_test", mode: :playback) do
           Open3.capture3("echo this should not execute")
         end
 
         expect(result).to be_playback
-        expect(result).to be_verified # Always true for playback
+        expect(result).to be_verified
         expect(result.stdout).to eq("playback\n")
       end
     end
 
     context "with custom matcher" do
       it "uses custom matcher for verification" do
-        # Record
         Backspin.run("custom_matcher") do
           Open3.capture3("ruby --version")
         end
 
-        # Verify with custom matcher
         result = Backspin.run("custom_matcher",
           matcher: lambda { |recorded, actual|
             recorded["stdout"].start_with?("ruby") &&
@@ -170,6 +156,50 @@ RSpec.describe "Backspin.run unified API" do
       end
     end
 
+    context "with raise_on_verification_failure set to false" do
+      it "returns result with verified? false instead of raising" do
+        Backspin.run("config_no_raise") do
+          Open3.capture3("echo original")
+        end
+
+        Backspin.configure do |config|
+          config.raise_on_verification_failure = false
+        end
+
+        result = Backspin.run("config_no_raise") do
+          Open3.capture3("echo different")
+        end
+
+        expect(result).not_to be_verified
+        expect(result.verified?).to be false
+        expect(result.diff).to include("-original")
+        expect(result.diff).to include("+different")
+        expect(result.error_message).to include("Output verification failed")
+      end
+
+      it "allows users to handle verification failures themselves" do
+        Backspin.run("config_handle_failure") do
+          Open3.capture3("echo expected")
+        end
+
+        Backspin.configuration.raise_on_verification_failure = false
+
+        result = Backspin.run("config_handle_failure") do
+          Open3.capture3("echo actual")
+        end
+
+        expect(result.verified?).to be false
+        expect(result.error_message).to be_a(String)
+        expect(result.diff).to include("-expected")
+        expect(result.diff).to include("+actual")
+
+        if !result.verified?
+          custom_message = "Verification failed: #{result.error_message}"
+          expect(custom_message).to include("Output verification failed")
+        end
+      end
+    end
+
     context "error handling" do
       it "requires record_name" do
         expect do
@@ -195,12 +225,10 @@ RSpec.describe "Backspin.run unified API" do
 
   describe "Backspin.run!" do
     it "returns result on successful verification" do
-      # Record
       Backspin.run("bang_success") do
         Open3.capture3("echo success")
       end
 
-      # Verify with run!
       result = Backspin.run!("bang_success") do
         Open3.capture3("echo success")
       end
@@ -210,12 +238,10 @@ RSpec.describe "Backspin.run unified API" do
     end
 
     it "raises on verification failure" do
-      # Record
       Backspin.run("bang_failure") do
         Open3.capture3("echo original")
       end
 
-      # Verify with different output
       expect do
         Backspin.run!("bang_failure") do
           Open3.capture3("echo different")
@@ -254,7 +280,6 @@ RSpec.describe "Backspin.run unified API" do
         status: 0
       )
 
-      # Verify that verified is nil but not included in the hash
       expect(result.verified?).to be_nil
 
       expect(result.inspect).to include("Backspin::RecordResult")


### PR DESCRIPTION
Change `Backspin.run` and `Backspin.capture` to raise by default on verification failure

This is controlled via the `raise_on_verification_failure` configuration setting, which now defaults to true.
This better suits the typical workflow for using backspin.

Both methods now behave identically with respect to the configuration:
- **When `raise_on_verification_failure = true` (default):**
  - `run` raises `RSpec::Expectations::ExpectationNotMetError`
  - `capture` raises `Backspin::VerificationError`
- **When `raise_on_verification_failure = false`:**
  - Both return a result with `verified? = false`

Note that this is a breaking change for how the API used to work - but you can transition by setting  `raise_on_verification_failure` to false in your Backspin config.