### PR TITLE
feat: add filter_on verify canonicalization pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.10.0 - 2026-02-11
 * Added `filter_on` to `Backspin.run` and `Backspin.capture` (`:both` default, `:record` opt-out).
 * Changed default filter behavior: `filter` now applies during verify comparisons/diffs when `filter_on: :both`.
 * Matcher callbacks now receive mutable copies of comparison data so in-place mutations do not mutate snapshots.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+* Added `filter_on` to `Backspin.run` and `Backspin.capture` (`:both` default, `:record` opt-out).
+* Changed default filter behavior: `filter` now applies during verify comparisons/diffs when `filter_on: :both`.
+* Matcher callbacks now receive mutable copies of comparison data so in-place mutations do not mutate snapshots.
+* Snapshot serialization is now immutable: `Snapshot#to_h` returns a frozen representation built at initialization.
+
 ## 0.9.0 - 2026-02-11
 * Breaking: `Backspin.run` and `Backspin.capture` now return `Backspin::BackspinResult` with explicit `result.actual` / `result.expected` snapshots.
 * Breaking: result convenience accessors (`result.stdout`, `result.stderr`, `result.status`) were removed in favor of snapshot access.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    backspin (0.9.0)
+    backspin (0.10.0)
 
 GEM
   remote: https://rubygems.org/

--- a/MATCHERS.md
+++ b/MATCHERS.md
@@ -77,6 +77,9 @@ The `:all` matcher receives full hashes with these keys:
 - `"env"` - Optional Hash of env vars (command runs only)
 - `"recorded_at"` - Timestamp string
 
+Matcher inputs are copies of comparison data so in-place mutation inside matcher callbacks
+does not mutate Backspin's stored snapshots.
+
 ## Examples
 
 ### Matching Version Numbers

--- a/MATCHERS.md
+++ b/MATCHERS.md
@@ -80,6 +80,21 @@ The `:all` matcher receives full hashes with these keys:
 Matcher inputs are copies of comparison data so in-place mutation inside matcher callbacks
 does not mutate Backspin's stored snapshots.
 
+Matcher callbacks should return a boolean. Any truthy return value is treated as pass,
+and false/nil is treated as failure.
+
+Example with safe in-place mutation:
+
+```ruby
+matcher = {
+  all: ->(recorded, actual) {
+    recorded["stdout"].gsub!(/id=\d+/, "id=[ID]")
+    actual["stdout"].gsub!(/id=\d+/, "id=[ID]")
+    recorded["stdout"] == actual["stdout"]
+  }
+}
+```
+
 ## Examples
 
 ### Matching Version Numbers

--- a/README.md
+++ b/README.md
@@ -132,6 +132,31 @@ result = Backspin.run(["date"], name: "timestamp_test", matcher: {stdout: timest
 
 For more matcher examples and detailed documentation, see [MATCHERS.md](MATCHERS.md).
 
+### Filters and Canonicalization
+
+Use `filter:` to normalize snapshot data (timestamps, random IDs, absolute paths).
+
+By default (`filter_on: :both`), Backspin applies `filter`:
+- when writing record snapshots
+- during verify for both expected and actual, before matcher and diff
+
+If you only want record-time filtering, use `filter_on: :record`.
+
+```ruby
+normalize_filter = ->(snapshot) do
+  snapshot.merge(
+    "stdout" => snapshot["stdout"].gsub(/id=\d+/, "id=[ID]")
+  )
+end
+
+# default: filter_on :both
+Backspin.run(["echo", "id=123"], name: "canonicalized", filter: normalize_filter)
+Backspin.run(["echo", "id=999"], name: "canonicalized", filter: normalize_filter) # verifies
+
+# record-only filtering
+Backspin.run(["echo", "id=123"], name: "record_only", filter: normalize_filter, filter_on: :record)
+```
+
 ### Working with the Result Object
 
 The API returns a `Backspin::BackspinResult` object with helpful methods:

--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ By default (`filter_on: :both`), Backspin applies `filter`:
 
 If you only want record-time filtering, use `filter_on: :record`.
 
+Migration note: older behavior applied `filter` only at record write. To preserve that behavior, set `filter_on: :record`.
+
 ```ruby
 normalize_filter = ->(snapshot) do
   snapshot.merge(
@@ -152,6 +154,14 @@ end
 # default: filter_on :both
 Backspin.run(["echo", "id=123"], name: "canonicalized", filter: normalize_filter)
 Backspin.run(["echo", "id=999"], name: "canonicalized", filter: normalize_filter) # verifies
+
+# capture also supports verify-time canonicalization
+Backspin.capture("capture_canonicalized", filter: normalize_filter) do
+  puts "id=123"
+end
+Backspin.capture("capture_canonicalized", filter: normalize_filter) do
+  puts "id=999"
+end
 
 # record-only filtering
 Backspin.run(["echo", "id=123"], name: "record_only", filter: normalize_filter, filter_on: :record)

--- a/docs/backspin-result-api-sketch.md
+++ b/docs/backspin-result-api-sketch.md
@@ -15,8 +15,8 @@ Branch: `spike-backspin-result-api`
 ### Entry points
 
 ```ruby
-Backspin.run(command = nil, name:, env: nil, mode: :auto, matcher: nil, filter: nil, &block)
-Backspin.capture(name, mode: :auto, matcher: nil, filter: nil, &block)
+Backspin.run(command = nil, name:, env: nil, mode: :auto, matcher: nil, filter: nil, filter_on: :both, &block)
+Backspin.capture(name, mode: :auto, matcher: nil, filter: nil, filter_on: :both, &block)
 ```
 
 Both return `BackspinResult`.
@@ -130,7 +130,8 @@ result.expected.stdout
 ## Matcher and Filter Semantics
 
 - `matcher:` applies only during verify and compares `expected` vs `actual`.
-- `filter:` applies only when writing snapshots to disk.
+- `filter:` applies during record writes, and during verify when `filter_on: :both`.
+- `filter_on:` supports `:both` (default) and `:record`.
 - `Snapshot` serializes once at initialization and returns a frozen hash from `to_h`.
 - Default match still compares stdout/stderr/status only.
 

--- a/docs/backspin-result-api-sketch.md
+++ b/docs/backspin-result-api-sketch.md
@@ -131,7 +131,7 @@ result.expected.stdout
 
 - `matcher:` applies only during verify and compares `expected` vs `actual`.
 - `filter:` applies only when writing snapshots to disk.
-- Verify internals materialize compare hashes once and reuse them for both matcher and diff generation.
+- `Snapshot` serializes once at initialization and returns a frozen hash from `to_h`.
 - Default match still compares stdout/stderr/status only.
 
 ## Error Semantics

--- a/docs/backspin-result-api-sketch.md
+++ b/docs/backspin-result-api-sketch.md
@@ -131,6 +131,7 @@ result.expected.stdout
 
 - `matcher:` applies only during verify and compares `expected` vs `actual`.
 - `filter:` applies only when writing snapshots to disk.
+- Verify internals materialize compare hashes once and reuse them for both matcher and diff generation.
 - Default match still compares stdout/stderr/status only.
 
 ## Error Semantics

--- a/lib/backspin/command_diff.rb
+++ b/lib/backspin/command_diff.rb
@@ -104,12 +104,8 @@ module Backspin
       diff_lines.join("\n")
     end
 
-    def expected_hash
-      @expected_hash
-    end
+    attr_reader :expected_hash
 
-    def actual_hash
-      @actual_hash
-    end
+    attr_reader :actual_hash
   end
 end

--- a/lib/backspin/command_diff.rb
+++ b/lib/backspin/command_diff.rb
@@ -8,18 +8,24 @@ module Backspin
     def initialize(expected:, actual:, matcher: nil)
       @expected = expected
       @actual = actual
+      @expected_hash = expected.to_h
+      @actual_hash = actual.to_h
       @matcher = Matcher.new(
         config: matcher,
         expected: expected,
-        actual: actual
+        actual: actual,
+        expected_hash: @expected_hash,
+        actual_hash: @actual_hash
       )
+      @verified = nil
     end
 
     # @return [Boolean] true if the snapshot output matches.
     def verified?
-      return false unless command_types_match?
+      return @verified unless @verified.nil?
+      return @verified = false unless command_types_match?
 
-      @matcher.match?
+      @verified = @matcher.match?
     end
 
     # @return [String, nil] Human-readable diff if not verified
@@ -27,8 +33,6 @@ module Backspin
       return nil if verified?
 
       parts = []
-      expected_hash = expected.to_h
-      actual_hash = actual.to_h
 
       unless command_types_match?
         parts << "Command type mismatch: expected #{expected.command_type.name}, got #{actual.command_type.name}"
@@ -98,6 +102,14 @@ module Backspin
       end
 
       diff_lines.join("\n")
+    end
+
+    def expected_hash
+      @expected_hash
+    end
+
+    def actual_hash
+      @actual_hash
     end
   end
 end

--- a/lib/backspin/command_diff.rb
+++ b/lib/backspin/command_diff.rb
@@ -5,13 +5,15 @@ module Backspin
   class CommandDiff
     attr_reader :expected, :actual, :matcher
 
-    def initialize(expected:, actual:, matcher: nil)
+    def initialize(expected:, actual:, matcher: nil, filter: nil, filter_on: :both)
       @expected = expected
       @actual = actual
+      @expected_compare = build_comparison_snapshot(expected, filter: filter, filter_on: filter_on)
+      @actual_compare = build_comparison_snapshot(actual, filter: filter, filter_on: filter_on)
       @matcher = Matcher.new(
         config: matcher,
-        expected: expected,
-        actual: actual
+        expected: @expected_compare,
+        actual: @actual_compare
       )
       @verified = nil
     end
@@ -34,16 +36,16 @@ module Backspin
         parts << "Command type mismatch: expected #{expected.command_type.name}, got #{actual.command_type.name}"
       end
 
-      if expected.stdout != actual.stdout
-        parts << stdout_diff(expected.stdout, actual.stdout)
+      if expected_compare.stdout != actual_compare.stdout
+        parts << stdout_diff(expected_compare.stdout, actual_compare.stdout)
       end
 
-      if expected.stderr != actual.stderr
-        parts << stderr_diff(expected.stderr, actual.stderr)
+      if expected_compare.stderr != actual_compare.stderr
+        parts << stderr_diff(expected_compare.stderr, actual_compare.stderr)
       end
 
-      if expected.status != actual.status
-        parts << "Exit status: expected #{expected.status}, got #{actual.status}"
+      if expected_compare.status != actual_compare.status
+        parts << "Exit status: expected #{expected_compare.status}, got #{actual_compare.status}"
       end
 
       parts.join("\n\n")
@@ -98,6 +100,65 @@ module Backspin
       end
 
       diff_lines.join("\n")
+    end
+
+    def expected_compare
+      @expected_compare
+    end
+
+    def actual_compare
+      @actual_compare
+    end
+
+    def build_comparison_snapshot(snapshot, filter:, filter_on:)
+      data = deep_dup(snapshot.to_h)
+      if filter && filter_on == :both
+        data = filter.call(data)
+      end
+
+      ComparisonSnapshot.new(
+        command_type: snapshot.command_type,
+        data: deep_freeze(data)
+      )
+    end
+
+    def deep_dup(value)
+      case value
+      when Hash
+        value.transform_values { |entry| deep_dup(entry) }
+      when Array
+        value.map { |entry| deep_dup(entry) }
+      when String
+        value.dup
+      else
+        value
+      end
+    end
+
+    def deep_freeze(value)
+      case value
+      when Hash
+        value.each_value { |entry| deep_freeze(entry) }
+      when Array
+        value.each { |entry| deep_freeze(entry) }
+      end
+      value.freeze
+    end
+
+    class ComparisonSnapshot
+      attr_reader :command_type, :stdout, :stderr, :status
+
+      def initialize(command_type:, data:)
+        @command_type = command_type
+        @data = data
+        @stdout = data["stdout"]
+        @stderr = data["stderr"]
+        @status = data["status"]
+      end
+
+      def to_h
+        @data
+      end
     end
 
   end

--- a/lib/backspin/command_diff.rb
+++ b/lib/backspin/command_diff.rb
@@ -8,14 +8,10 @@ module Backspin
     def initialize(expected:, actual:, matcher: nil)
       @expected = expected
       @actual = actual
-      @expected_hash = expected.to_h
-      @actual_hash = actual.to_h
       @matcher = Matcher.new(
         config: matcher,
         expected: expected,
-        actual: actual,
-        expected_hash: @expected_hash,
-        actual_hash: @actual_hash
+        actual: actual
       )
       @verified = nil
     end
@@ -38,16 +34,16 @@ module Backspin
         parts << "Command type mismatch: expected #{expected.command_type.name}, got #{actual.command_type.name}"
       end
 
-      if expected_hash["stdout"] != actual_hash["stdout"]
-        parts << stdout_diff(expected_hash["stdout"], actual_hash["stdout"])
+      if expected.stdout != actual.stdout
+        parts << stdout_diff(expected.stdout, actual.stdout)
       end
 
-      if expected_hash["stderr"] != actual_hash["stderr"]
-        parts << stderr_diff(expected_hash["stderr"], actual_hash["stderr"])
+      if expected.stderr != actual.stderr
+        parts << stderr_diff(expected.stderr, actual.stderr)
       end
 
-      if expected_hash["status"] != actual_hash["status"]
-        parts << "Exit status: expected #{expected_hash["status"]}, got #{actual_hash["status"]}"
+      if expected.status != actual.status
+        parts << "Exit status: expected #{expected.status}, got #{actual.status}"
       end
 
       parts.join("\n\n")
@@ -104,8 +100,5 @@ module Backspin
       diff_lines.join("\n")
     end
 
-    attr_reader :expected_hash
-
-    attr_reader :actual_hash
   end
 end

--- a/lib/backspin/command_diff.rb
+++ b/lib/backspin/command_diff.rb
@@ -102,13 +102,9 @@ module Backspin
       diff_lines.join("\n")
     end
 
-    def expected_compare
-      @expected_compare
-    end
+    attr_reader :expected_compare
 
-    def actual_compare
-      @actual_compare
-    end
+    attr_reader :actual_compare
 
     def build_comparison_snapshot(snapshot, filter:, filter_on:)
       data = deep_dup(snapshot.to_h)
@@ -160,6 +156,5 @@ module Backspin
         @data
       end
     end
-
   end
 end

--- a/lib/backspin/matcher.rb
+++ b/lib/backspin/matcher.rb
@@ -40,16 +40,14 @@ module Backspin
     end
 
     def evaluation
-      @evaluation ||= begin
-        if config.nil?
-          evaluate_default
-        elsif config.is_a?(Proc)
-          evaluate_proc
-        elsif config.is_a?(Hash)
-          evaluate_hash
-        else
-          raise ArgumentError, "Invalid matcher type: #{config.class}"
-        end
+      @evaluation ||= if config.nil?
+        evaluate_default
+      elsif config.is_a?(Proc)
+        evaluate_proc
+      elsif config.is_a?(Hash)
+        evaluate_hash
+      else
+        raise ArgumentError, "Invalid matcher type: #{config.class}"
       end
     end
 

--- a/lib/backspin/matcher.rb
+++ b/lib/backspin/matcher.rb
@@ -13,42 +13,12 @@ module Backspin
 
     # @return [Boolean] true if snapshots match according to configured matcher
     def match?
-      if config.nil?
-        default_match?
-      elsif config.is_a?(Proc)
-        config.call(expected_hash, actual_hash)
-      elsif config.is_a?(Hash)
-        verify_with_hash_matcher
-      else
-        raise ArgumentError, "Invalid matcher type: #{config.class}"
-      end
+      evaluation[:match]
     end
 
     # @return [String] reason why matching failed
     def failure_reason
-      reasons = []
-
-      if config.nil?
-        reasons << "stdout differs" if expected.stdout != actual.stdout
-        reasons << "stderr differs" if expected.stderr != actual.stderr
-        reasons << "exit status differs" if expected.status != actual.status
-      elsif config.is_a?(Hash)
-        config.each do |field, matcher_proc|
-          case field
-          when :all
-            reasons << ":all matcher failed" unless matcher_proc.call(expected_hash, actual_hash)
-          when :stdout, :stderr, :status
-            unless matcher_proc.call(expected.public_send(field), actual.public_send(field))
-              reasons << "#{field} custom matcher failed"
-            end
-          end
-        end
-      else
-        # Proc matcher
-        reasons << "custom matcher failed"
-      end
-
-      reasons.join(", ")
+      evaluation[:reason]
     end
 
     private
@@ -69,25 +39,55 @@ module Backspin
       config
     end
 
-    def verify_with_hash_matcher
-      results = config.map do |field, matcher_proc|
-        case field
+    def evaluation
+      @evaluation ||= begin
+        if config.nil?
+          evaluate_default
+        elsif config.is_a?(Proc)
+          evaluate_proc
+        elsif config.is_a?(Hash)
+          evaluate_hash
+        else
+          raise ArgumentError, "Invalid matcher type: #{config.class}"
+        end
+      end
+    end
+
+    def evaluate_default
+      reasons = []
+      reasons << "stdout differs" if expected.stdout != actual.stdout
+      reasons << "stderr differs" if expected.stderr != actual.stderr
+      reasons << "exit status differs" if expected.status != actual.status
+
+      {match: reasons.empty?, reason: reasons.join(", ")}
+    end
+
+    def evaluate_proc
+      match = !!config.call(deep_dup(expected_hash), deep_dup(actual_hash))
+      reason = match ? "" : "custom matcher failed"
+      {match: match, reason: reason}
+    end
+
+    def evaluate_hash
+      reasons = []
+
+      config.each do |field, matcher_proc|
+        passed = case field
         when :all
-          matcher_proc.call(expected_hash, actual_hash)
+          matcher_proc.call(deep_dup(expected_hash), deep_dup(actual_hash))
         when :stdout, :stderr, :status
-          matcher_proc.call(expected.public_send(field), actual.public_send(field))
+          matcher_proc.call(deep_dup(expected.public_send(field)), deep_dup(actual.public_send(field)))
         else
           raise ArgumentError, "Unknown field: #{field}"
         end
+
+        next if passed
+
+        reasons << ":all matcher failed" if field == :all
+        reasons << "#{field} custom matcher failed" if %i[stdout stderr status].include?(field)
       end
 
-      results.all?
-    end
-
-    def default_match?
-      expected.stdout == actual.stdout &&
-        expected.stderr == actual.stderr &&
-        expected.status == actual.status
+      {match: reasons.empty?, reason: reasons.join(", ")}
     end
 
     def expected_hash
@@ -96,6 +96,19 @@ module Backspin
 
     def actual_hash
       @actual_hash ||= actual.to_h
+    end
+
+    def deep_dup(value)
+      case value
+      when Hash
+        value.transform_values { |entry| deep_dup(entry) }
+      when Array
+        value.map { |entry| deep_dup(entry) }
+      when String
+        value.dup
+      else
+        value
+      end
     end
   end
 end

--- a/lib/backspin/recorder.rb
+++ b/lib/backspin/recorder.rb
@@ -6,13 +6,14 @@ require "backspin/command_diff"
 module Backspin
   # Handles capture-mode recording and verification
   class Recorder
-    attr_reader :mode, :record, :matcher, :filter
+    attr_reader :mode, :record, :matcher, :filter, :filter_on
 
-    def initialize(mode: :record, record: nil, matcher: nil, filter: nil)
+    def initialize(mode: :record, record: nil, matcher: nil, filter: nil, filter_on: :both)
       @mode = mode
       @record = record
       @matcher = matcher
       @filter = filter
+      @filter_on = filter_on
     end
 
     # Performs capture recording by intercepting all stdout/stderr output
@@ -62,7 +63,9 @@ module Backspin
       command_diff = CommandDiff.new(
         expected: expected_snapshot,
         actual: actual_snapshot,
-        matcher: @matcher
+        matcher: @matcher,
+        filter: @filter,
+        filter_on: @filter_on
       )
 
       BackspinResult.new(

--- a/lib/backspin/snapshot.rb
+++ b/lib/backspin/snapshot.rb
@@ -115,7 +115,6 @@ module Backspin
         value
       end
     end
-
   end
 end
 

--- a/lib/backspin/snapshot.rb
+++ b/lib/backspin/snapshot.rb
@@ -7,12 +7,13 @@ module Backspin
 
     def initialize(command_type:, args:, env: nil, stdout: "", stderr: "", status: 0, recorded_at: nil)
       @command_type = command_type
-      @args = args
-      @env = env
-      @stdout = stdout || ""
-      @stderr = stderr || ""
+      @args = sanitize_args(args)
+      @env = env.nil? ? nil : sanitize_env(env)
+      @stdout = Backspin.scrub_text((stdout || "").dup).freeze
+      @stderr = Backspin.scrub_text((stderr || "").dup).freeze
       @status = status || 0
-      @recorded_at = recorded_at
+      @recorded_at = recorded_at.nil? ? nil : recorded_at.dup.freeze
+      @serialized_hash = build_serialized_hash
     end
 
     def success?
@@ -23,10 +24,8 @@ module Backspin
       !success?
     end
 
-    def to_h(filter: nil)
-      return base_hash if filter.nil?
-
-      filter.call(deep_dup(base_hash))
+    def to_h
+      @serialized_hash
     end
 
     def self.from_h(data)
@@ -52,19 +51,17 @@ module Backspin
 
     private
 
-    def base_hash
-      @base_hash ||= begin
-        data = {
-          "command_type" => command_type.name,
-          "args" => scrub_args(args),
-          "stdout" => Backspin.scrub_text(stdout),
-          "stderr" => Backspin.scrub_text(stderr),
-          "status" => status,
-          "recorded_at" => recorded_at
-        }
-        data["env"] = scrub_env(env) if env
-        deep_freeze(data)
-      end
+    def build_serialized_hash
+      data = {
+        "command_type" => command_type.name,
+        "args" => args,
+        "stdout" => stdout,
+        "stderr" => stderr,
+        "status" => status,
+        "recorded_at" => recorded_at
+      }
+      data["env"] = env if env
+      deep_freeze(data)
     end
 
     def scrub_args(value)
@@ -88,6 +85,14 @@ module Backspin
       value.transform_values { |entry| entry.is_a?(String) ? Backspin.scrub_text(entry) : entry }
     end
 
+    def sanitize_args(value)
+      deep_freeze(scrub_args(deep_dup(value)))
+    end
+
+    def sanitize_env(value)
+      deep_freeze(scrub_env(deep_dup(value)))
+    end
+
     def deep_freeze(value)
       case value
       when Hash
@@ -101,15 +106,16 @@ module Backspin
     def deep_dup(value)
       case value
       when Hash
-        value.transform_values { |v| deep_dup(v) }
+        value.transform_values { |entry| deep_dup(entry) }
       when Array
-        value.map { |v| deep_dup(v) }
+        value.map { |entry| deep_dup(entry) }
       when String
         value.dup
       else
         value
       end
     end
+
   end
 end
 

--- a/lib/backspin/version.rb
+++ b/lib/backspin/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Backspin
-  VERSION = "0.9.0"
+  VERSION = "0.10.0"
 end

--- a/spec/backspin/command_diff_spec.rb
+++ b/spec/backspin/command_diff_spec.rb
@@ -40,7 +40,18 @@ RSpec.describe Backspin::CommandDiff do
     expect(stderr_index).to be < status_index
   end
 
-  it "does not call to_h when building default diffs" do
+  it "materializes compare hashes once and reuses them for verify and diff" do
+    expected_hash = {
+      "stdout" => "one\n",
+      "stderr" => "err\n",
+      "status" => 0
+    }
+    actual_hash = {
+      "stdout" => "two\n",
+      "stderr" => "bad\n",
+      "status" => 1
+    }
+
     expected_snapshot = instance_double(
       Backspin::Snapshot,
       command_type: Open3::Capture3,
@@ -56,8 +67,8 @@ RSpec.describe Backspin::CommandDiff do
       status: 1
     )
 
-    expect(expected_snapshot).not_to receive(:to_h)
-    expect(actual_snapshot).not_to receive(:to_h)
+    expect(expected_snapshot).to receive(:to_h).once.and_return(expected_hash)
+    expect(actual_snapshot).to receive(:to_h).once.and_return(actual_hash)
 
     command_diff = described_class.new(
       expected: expected_snapshot,

--- a/spec/backspin/command_diff_spec.rb
+++ b/spec/backspin/command_diff_spec.rb
@@ -80,5 +80,4 @@ RSpec.describe Backspin::CommandDiff do
     expect(command_diff.diff).to include("[stderr]")
     expect(command_diff.diff).to include("Exit status: expected 0, got 1")
   end
-
 end

--- a/spec/backspin/command_diff_spec.rb
+++ b/spec/backspin/command_diff_spec.rb
@@ -40,29 +40,24 @@ RSpec.describe Backspin::CommandDiff do
     expect(stderr_index).to be < status_index
   end
 
-  it "materializes snapshot hashes once and reuses them for verify and diff" do
-    expected_hash = {
-      "stdout" => "one\n",
-      "stderr" => "err\n",
-      "status" => 0
-    }
-    actual_hash = {
-      "stdout" => "two\n",
-      "stderr" => "bad\n",
-      "status" => 1
-    }
-
+  it "does not call to_h when building default diffs" do
     expected_snapshot = instance_double(
       Backspin::Snapshot,
-      command_type: Open3::Capture3
+      command_type: Open3::Capture3,
+      stdout: "one\n",
+      stderr: "err\n",
+      status: 0
     )
     actual_snapshot = instance_double(
       Backspin::Snapshot,
-      command_type: Open3::Capture3
+      command_type: Open3::Capture3,
+      stdout: "two\n",
+      stderr: "bad\n",
+      status: 1
     )
 
-    expect(expected_snapshot).to receive(:to_h).once.and_return(expected_hash)
-    expect(actual_snapshot).to receive(:to_h).once.and_return(actual_hash)
+    expect(expected_snapshot).not_to receive(:to_h)
+    expect(actual_snapshot).not_to receive(:to_h)
 
     command_diff = described_class.new(
       expected: expected_snapshot,
@@ -70,9 +65,9 @@ RSpec.describe Backspin::CommandDiff do
     )
 
     expect(command_diff.verified?).to be false
-    expect(command_diff.summary).to include("Command failed")
     expect(command_diff.diff).to include("[stdout]")
     expect(command_diff.diff).to include("[stderr]")
     expect(command_diff.diff).to include("Exit status: expected 0, got 1")
   end
+
 end

--- a/spec/backspin/snapshot_spec.rb
+++ b/spec/backspin/snapshot_spec.rb
@@ -3,16 +3,25 @@
 require "spec_helper"
 
 RSpec.describe Backspin::Snapshot do
-  it "memoizes and deep-freezes the unfiltered hash payload" do
+  around do |example|
+    with_tmp_dir_for_backspin(&example)
+  end
+
+  it "stores and deep-freezes the serialized hash at initialization" do
+    args = ["echo", "hello"]
+    env = {"FOO" => "bar"}
     snapshot = described_class.new(
       command_type: Open3::Capture3,
-      args: ["echo", "hello"],
-      env: {"FOO" => "bar"},
+      args: args,
+      env: env,
       stdout: "hello\n",
       stderr: "",
       status: 0,
       recorded_at: "2026-02-11T00:00:00Z"
     )
+
+    args << "changed"
+    env["FOO"] = "changed"
 
     first = snapshot.to_h
     second = snapshot.to_h
@@ -22,9 +31,29 @@ RSpec.describe Backspin::Snapshot do
     expect(first["args"]).to be_frozen
     expect(first["env"]).to be_frozen
     expect(first["stdout"]).to be_frozen
+    expect(first["args"]).to eq(["echo", "hello"])
+    expect(first["env"]).to eq({"FOO" => "bar"})
   end
 
-  it "gives filters a mutable copy without mutating the cached base hash" do
+  it "captures scrubbing behavior at initialization time" do
+    snapshot = described_class.new(
+      command_type: Open3::Capture3,
+      args: ["echo", "AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE"],
+      stdout: "AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE\n",
+      stderr: "",
+      status: 0
+    )
+
+    Backspin.configure do |config|
+      config.scrub_credentials = false
+    end
+
+    data = snapshot.to_h
+    expect(data["stdout"]).to eq("AWS_ACCESS_KEY_ID=********************\n")
+    expect(data["args"]).to eq(["echo", "AWS_ACCESS_KEY_ID=********************"])
+  end
+
+  it "returns the same frozen hash on each to_h call" do
     snapshot = described_class.new(
       command_type: Open3::Capture3,
       args: ["echo", "hello"],
@@ -34,41 +63,10 @@ RSpec.describe Backspin::Snapshot do
       status: 0
     )
 
-    base = snapshot.to_h
+    data_a = snapshot.to_h
+    data_b = snapshot.to_h
 
-    filtered = snapshot.to_h(filter: lambda { |data|
-      data["stdout"].gsub!("hello", "filtered")
-      data["args"] << "extra"
-      data["env"]["FOO"] = "changed"
-      data
-    })
-
-    expect(filtered["stdout"]).to eq("filtered\n")
-    expect(filtered["args"]).to eq(["echo", "hello", "extra"])
-    expect(filtered["env"]).to eq({"FOO" => "changed"})
-
-    expect(base["stdout"]).to eq("hello\n")
-    expect(base["args"]).to eq(["echo", "hello"])
-    expect(base["env"]).to eq({"FOO" => "bar"})
-  end
-
-  it "runs filter on every filtered to_h call" do
-    snapshot = described_class.new(
-      command_type: Open3::Capture3,
-      args: ["echo", "hello"],
-      stdout: "hello\n",
-      stderr: "",
-      status: 0
-    )
-
-    calls = 0
-    filter = lambda { |data|
-      calls += 1
-      data.merge("stdout" => "call-#{calls}\n")
-    }
-
-    expect(snapshot.to_h(filter: filter)["stdout"]).to eq("call-1\n")
-    expect(snapshot.to_h(filter: filter)["stdout"]).to eq("call-2\n")
-    expect(calls).to eq(2)
+    expect(data_a.object_id).to eq(data_b.object_id)
+    expect(data_a).to be_frozen
   end
 end

--- a/spec/backspin/snapshot_spec.rb
+++ b/spec/backspin/snapshot_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Backspin::Snapshot do
+  it "memoizes and deep-freezes the unfiltered hash payload" do
+    snapshot = described_class.new(
+      command_type: Open3::Capture3,
+      args: ["echo", "hello"],
+      env: {"FOO" => "bar"},
+      stdout: "hello\n",
+      stderr: "",
+      status: 0,
+      recorded_at: "2026-02-11T00:00:00Z"
+    )
+
+    first = snapshot.to_h
+    second = snapshot.to_h
+
+    expect(first.object_id).to eq(second.object_id)
+    expect(first).to be_frozen
+    expect(first["args"]).to be_frozen
+    expect(first["env"]).to be_frozen
+    expect(first["stdout"]).to be_frozen
+  end
+
+  it "gives filters a mutable copy without mutating the cached base hash" do
+    snapshot = described_class.new(
+      command_type: Open3::Capture3,
+      args: ["echo", "hello"],
+      env: {"FOO" => "bar"},
+      stdout: "hello\n",
+      stderr: "",
+      status: 0
+    )
+
+    base = snapshot.to_h
+
+    filtered = snapshot.to_h(filter: lambda { |data|
+      data["stdout"].gsub!("hello", "filtered")
+      data["args"] << "extra"
+      data["env"]["FOO"] = "changed"
+      data
+    })
+
+    expect(filtered["stdout"]).to eq("filtered\n")
+    expect(filtered["args"]).to eq(["echo", "hello", "extra"])
+    expect(filtered["env"]).to eq({"FOO" => "changed"})
+
+    expect(base["stdout"]).to eq("hello\n")
+    expect(base["args"]).to eq(["echo", "hello"])
+    expect(base["env"]).to eq({"FOO" => "bar"})
+  end
+
+  it "runs filter on every filtered to_h call" do
+    snapshot = described_class.new(
+      command_type: Open3::Capture3,
+      args: ["echo", "hello"],
+      stdout: "hello\n",
+      stderr: "",
+      status: 0
+    )
+
+    calls = 0
+    filter = lambda { |data|
+      calls += 1
+      data.merge("stdout" => "call-#{calls}\n")
+    }
+
+    expect(snapshot.to_h(filter: filter)["stdout"]).to eq("call-1\n")
+    expect(snapshot.to_h(filter: filter)["stdout"]).to eq("call-2\n")
+    expect(calls).to eq(2)
+  end
+end

--- a/spec/backspin_capture_spec.rb
+++ b/spec/backspin_capture_spec.rb
@@ -162,4 +162,10 @@ RSpec.describe "Backspin.capture" do
       expect(error.message).to include("Output verification failed")
     end
   end
+
+  it "rejects unknown filter_on values" do
+    expect do
+      Backspin.capture("capture_bad_filter_on", filter_on: :verify) { puts "hi" }
+    end.to raise_error(ArgumentError, /Unknown filter_on/)
+  end
 end

--- a/spec/backspin_filter_spec.rb
+++ b/spec/backspin_filter_spec.rb
@@ -57,4 +57,119 @@ RSpec.describe "Backspin record filters" do
     expect(record_data["snapshot"]["stdout"]).to eq("filtered\n")
     expect(record_data["snapshot"]["args"]).to eq(["echo", "hello", "extra"])
   end
+
+  it "applies filter to expected and actual during verify by default for run" do
+    filter = lambda do |data|
+      data.merge("stdout" => data["stdout"].gsub(/id=\d+/, "id=[ID]"))
+    end
+
+    Backspin.run(["echo", "id=123"], name: "filter_on_both_run", mode: :record, filter: filter)
+    result = Backspin.run(["echo", "id=999"], name: "filter_on_both_run", mode: :verify, filter: filter)
+
+    expect(result).to be_verified
+  end
+
+  it "can restrict filter application to record-only verify behavior for run" do
+    filter = lambda do |data|
+      data.merge("stdout" => data["stdout"].gsub(/id=\d+/, "id=[ID]"))
+    end
+
+    Backspin.run(
+      ["echo", "id=123"],
+      name: "filter_on_record_run",
+      mode: :record,
+      filter: filter,
+      filter_on: :record
+    )
+
+    expect do
+      Backspin.run(
+        ["echo", "id=999"],
+        name: "filter_on_record_run",
+        mode: :verify,
+        filter: filter,
+        filter_on: :record
+      )
+    end.to raise_error(Backspin::VerificationError)
+  end
+
+  it "provides filtered hashes to proc matchers when filter_on is :both" do
+    filter = lambda do |data|
+      data.merge("stdout" => data["stdout"].gsub(/id=\d+/, "id=[ID]"))
+    end
+    seen = nil
+    matcher = lambda do |recorded, actual|
+      seen = [recorded["stdout"], actual["stdout"]]
+      recorded["stdout"] == actual["stdout"]
+    end
+
+    Backspin.run(["echo", "id=100"], name: "filter_matcher_interaction", mode: :record, filter: filter)
+    result = Backspin.run(
+      ["echo", "id=200"],
+      name: "filter_matcher_interaction",
+      mode: :verify,
+      filter: filter,
+      matcher: matcher
+    )
+
+    expect(result).to be_verified
+    expect(seen).to eq(["id=[ID]\n", "id=[ID]\n"])
+  end
+
+  it "generates diffs from filtered values when filter_on is :both" do
+    filter = lambda do |data|
+      data.merge("stdout" => data["stdout"].gsub(/id=\d+/, "id=[ID]"))
+    end
+
+    Backspin.run(["echo", "id=123 one"], name: "filter_diff_output", mode: :record, filter: filter)
+
+    Backspin.configure do |config|
+      config.raise_on_verification_failure = false
+    end
+
+    result = Backspin.run(
+      ["echo", "id=999 two"],
+      name: "filter_diff_output",
+      mode: :verify,
+      filter: filter
+    )
+
+    expect(result.verified?).to be false
+    expect(result.diff).to include("-id=[ID] one")
+    expect(result.diff).to include("+id=[ID] two")
+    expect(result.diff).not_to include("id=123")
+    expect(result.diff).not_to include("id=999")
+  end
+
+  it "applies filter to expected and actual during verify by default for capture" do
+    filter = lambda do |data|
+      data.merge("stdout" => data["stdout"].gsub(/id=\d+/, "id=[ID]"))
+    end
+
+    Backspin.capture("filter_on_both_capture", mode: :record, filter: filter) do
+      puts "id=111"
+    end
+
+    result = Backspin.capture("filter_on_both_capture", mode: :verify, filter: filter) do
+      puts "id=222"
+    end
+
+    expect(result).to be_verified
+  end
+
+  it "can restrict filter application to record-only verify behavior for capture" do
+    filter = lambda do |data|
+      data.merge("stdout" => data["stdout"].gsub(/id=\d+/, "id=[ID]"))
+    end
+
+    Backspin.capture("filter_on_record_capture", mode: :record, filter: filter, filter_on: :record) do
+      puts "id=111"
+    end
+
+    expect do
+      Backspin.capture("filter_on_record_capture", mode: :verify, filter: filter, filter_on: :record) do
+        puts "id=222"
+      end
+    end.to raise_error(Backspin::VerificationError)
+  end
 end

--- a/spec/backspin_matcher_spec.rb
+++ b/spec/backspin_matcher_spec.rb
@@ -219,4 +219,33 @@ RSpec.describe "Backspin matcher contract" do
 
     expect(matcher.match?).to be true
   end
+
+  it "materializes snapshot hashes once across match and failure reason" do
+    expected_hash = {
+      "stdout" => "one\n",
+      "stderr" => "",
+      "status" => 0
+    }
+    actual_hash = {
+      "stdout" => "two\n",
+      "stderr" => "",
+      "status" => 0
+    }
+
+    expected_snapshot = instance_double(Backspin::Snapshot)
+    actual_snapshot = instance_double(Backspin::Snapshot)
+
+    expect(expected_snapshot).to receive(:to_h).once.and_return(expected_hash)
+    expect(actual_snapshot).to receive(:to_h).once.and_return(actual_hash)
+
+    matcher = Backspin::Matcher.new(
+      config: nil,
+      expected: expected_snapshot,
+      actual: actual_snapshot
+    )
+
+    expect(matcher.match?).to be false
+    expect(matcher.failure_reason).to include("stdout differs")
+    expect(matcher.match?).to be false
+  end
 end

--- a/spec/backspin_matcher_spec.rb
+++ b/spec/backspin_matcher_spec.rb
@@ -346,5 +346,4 @@ RSpec.describe "Backspin matcher contract" do
     expect(recorded_command.to_h["stdout"]).to eq("id=100\n")
     expect(actual_command.to_h["stdout"]).to eq("id=200\n")
   end
-
 end

--- a/spec/backspin_run_spec.rb
+++ b/spec/backspin_run_spec.rb
@@ -243,4 +243,10 @@ RSpec.describe "Backspin.run" do
       Backspin.run(["echo", "hi"], name: "no_playback", mode: :playback)
     end.to raise_error(ArgumentError, /Playback mode is not supported/)
   end
+
+  it "rejects unknown filter_on values" do
+    expect do
+      Backspin.run(["echo", "hi"], name: "bad_filter_on", filter_on: :verify)
+    end.to raise_error(ArgumentError, /Unknown filter_on/)
+  end
 end


### PR DESCRIPTION
## Summary
- add `filter_on` to `Backspin.run` and `Backspin.capture` with `:both` default and `:record` opt-out
- apply `filter` during verify when `filter_on: :both`, using one canonicalized compare view for matcher and diff
- keep `Snapshot` immutable (`to_h` returns frozen serialized data)
- move record-time filter application to `Record.save` on a deep-dup copy
- keep matcher compatibility by passing mutable copies into proc and `:all` matcher callbacks

## Why
This makes dynamic-output canonicalization the default, removes matcher/diff drift risk, and preserves matcher flexibility without mutating stored snapshots.

## Behavior Notes
- `filter_on: :both` (default): filter applies at record write and verify compare-time
- `filter_on: :record`: filter applies only at record write
- default matcher/diff paths compare snapshot fields directly
- proc and `:all` hash matchers still receive full hashes (as deep-duped copies)

## Validation
- `bundle exec rspec`
- result: 83 examples, 0 failures

## Files
- core: `lib/backspin.rb`, `lib/backspin/recorder.rb`, `lib/backspin/command_diff.rb`, `lib/backspin/matcher.rb`, `lib/backspin/record.rb`
- docs: `README.md`, `MATCHERS.md`, `docs/backspin-result-api-sketch.md`
- tests: `spec/backspin_filter_spec.rb`, `spec/backspin_run_spec.rb`, `spec/backspin_capture_spec.rb`, `spec/backspin_matcher_spec.rb`, `spec/backspin/command_diff_spec.rb`