### PR TITLE
Store timestamps as UTC instead of local timezone

### DIFF
--- a/lib/backspin.rb
+++ b/lib/backspin.rb
@@ -159,7 +159,7 @@ module Backspin
           stdout: stdout,
           stderr: stderr,
           status: status.exitstatus,
-          recorded_at: Time.now.iso8601
+          recorded_at: Time.now.utc.iso8601
         )
         record.set_snapshot(actual_snapshot)
         record.save(filter: filter)

--- a/lib/backspin/record.rb
+++ b/lib/backspin/record.rb
@@ -44,7 +44,7 @@ module Backspin
 
     def set_snapshot(snapshot)
       @snapshot = snapshot
-      snapshot_recorded_at = snapshot.recorded_at || Time.now.iso8601
+      snapshot_recorded_at = snapshot.recorded_at || Time.now.utc.iso8601
       @first_recorded_at ||= snapshot_recorded_at
       @recorded_at = snapshot_recorded_at
       self

--- a/lib/backspin/recorder.rb
+++ b/lib/backspin/recorder.rb
@@ -26,7 +26,7 @@ module Backspin
         stdout: captured_stdout,
         stderr: captured_stderr,
         status: 0,
-        recorded_at: Time.now.iso8601
+        recorded_at: Time.now.utc.iso8601
       )
 
       record.set_snapshot(actual_snapshot)

--- a/spec/acceptance/record_format_v4_1_spec.rb
+++ b/spec/acceptance/record_format_v4_1_spec.rb
@@ -119,6 +119,30 @@ RSpec.describe "Record format v4.1" do
     expect(unchanged_record["format_version"]).to eq("4.0")
   end
 
+  it "stores run timestamps in UTC" do
+    Backspin.run(["echo", "utc check"], name: "run_utc_timestamps")
+
+    record_path = Backspin.configuration.backspin_dir.join("run_utc_timestamps.yml")
+    record_data = YAML.load_file(record_path)
+
+    expect(record_data["first_recorded_at"]).to end_with("Z")
+    expect(record_data["recorded_at"]).to end_with("Z")
+    expect(record_data["snapshot"]["recorded_at"]).to end_with("Z")
+  end
+
+  it "stores capture timestamps in UTC" do
+    Backspin.capture("capture_utc_timestamps") do
+      puts "utc check"
+    end
+
+    record_path = Backspin.configuration.backspin_dir.join("capture_utc_timestamps.yml")
+    record_data = YAML.load_file(record_path)
+
+    expect(record_data["first_recorded_at"]).to end_with("Z")
+    expect(record_data["recorded_at"]).to end_with("Z")
+    expect(record_data["snapshot"]["recorded_at"]).to end_with("Z")
+  end
+
   it "upgrades a 4.0 record to v4.1 metadata on re-record" do
     record_path = Backspin.configuration.backspin_dir.join("upgrade_from_v4_0.yml")
     FileUtils.mkdir_p(File.dirname(record_path))


### PR DESCRIPTION
## Summary

* Change `Time.now.iso8601` to `Time.now.utc.iso8601` in all three timestamp generation sites (`lib/backspin.rb`, `lib/backspin/record.rb`, `lib/backspin/recorder.rb`)
* Add regression tests for both `run` and `capture` paths verifying timestamps end with `Z`
* Existing snapshots with local timezone offsets naturally upgrade to UTC on next re-record — no format version bump needed

Fixes #35

